### PR TITLE
Clarify ICMP Extension Structure checksum scope in Section 1.3

### DIFF
--- a/draft-ietf-intarea-rfc8335bis.md
+++ b/draft-ietf-intarea-rfc8335bis.md
@@ -208,8 +208,13 @@ extension object is an Interface Identification Object as defined
 in this memo, then the extension structure (including the
 checksum) consists only of that single ICMP Extension Object.
 This is done to maintain compatibility with the initial set
-of implementations of RFC8335, which behave this way.  New
-uses of ICMP Extensions, and in fact uses of Extended Echo
+of implementations of RFC8335, which behave this way.
+The ICMP Extension Structure checksum covers only the Interface
+Identification Object.  Any data following it is not covered by
+this checksum but is covered by the ICMP header checksum, which
+protects the entire ICMP message (see {{security}} for further
+discussion).
+New uses of ICMP Extensions, and in fact uses of Extended Echo
 using some object other than the Interface Identification Object,
 SHOULD NOT behave this way.  Uses other than defined in this
 memo SHOULD treat the ICMP Extension Structure as extending


### PR DESCRIPTION
Add text explaining that the Extension Structure checksum covers only the Interface Identification Object, while any data following it is protected by the ICMP header checksum which covers the entire message. Cross-references Security Considerations for further discussion.

Fixes #19, fixes #25